### PR TITLE
chore: add CLAUDE.md, .superset/setup.sh, and TASK.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Per-worktree scratch file
+TASK.md

--- a/.superset/setup.sh
+++ b/.superset/setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Superset worktree setup script for ApiPythonSample
+set -euo pipefail
+
+BRANCH_NAME="${1:-$(git rev-parse --abbrev-ref HEAD)}"
+
+echo "Setting up ApiPythonSample worktree for branch: $BRANCH_NAME"
+
+# Copy env files from the root repo if available
+if [ -n "${SUPERSET_ROOT_PATH:-}" ]; then
+  for envfile in .env .env.example; do
+    if [ -f "$SUPERSET_ROOT_PATH/$envfile" ]; then
+      cp "$SUPERSET_ROOT_PATH/$envfile" "./$envfile"
+      echo "Copied $envfile from root"
+    fi
+  done
+fi
+
+# Install Python dependencies
+echo "Installing Python dependencies..."
+pip install -r requirements.txt
+
+echo ""
+echo "Setup complete for branch: $BRANCH_NAME"
+echo "  - Run: python sample.py"
+echo "  - Configure .env with your Client ID and Secret first"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+> Cross-repo system map lives in `~/.claude/CLAUDE.md` (user-level, not committed).
+
+## Overview
+
+ApiPythonSample — a public sample project demonstrating how to authenticate with and consume the Qonic Public API using Python. Intended as a reference for third-party developers.
+
+## Tech Stack
+
+- **Python 3.10+**
+- **requests 2.29** — HTTP client
+- **python-dotenv** — environment variable loading
+
+## Commands
+
+```bash
+# Setup
+cp .env.example .env     # Copy env template, then fill in credentials
+pip install -r requirements.txt
+
+# Run
+python sample.py         # Opens browser for OAuth login, then demonstrates API calls
+```
+
+## Project Structure
+
+```
+sample.py              # Main entry point — config, auth flow, example API requests
+oauth.py               # OAuth authorization code flow with PKCE
+QonicApi.py            # API client wrapper (high-level methods)
+QonicApiLib.py         # Low-level API request helpers
+printMethods.py        # Pretty-print utilities for API responses
+requirements.txt       # Python dependencies
+.env.example           # Environment variable template
+```
+
+## Key Conventions
+
+- Uses OAuth **authorization code flow with PKCE** — a local HTTP server on `QONIC_LOCAL_PORT` (default 8765) captures the callback
+- The `QONIC_REDIRECT_URI` must exactly match a whitelisted redirect URI in the Qonic Developer Portal
+- Scopes are space-separated in `QONIC_SCOPES` (e.g., `projects:read models:read`)
+
+## Environment Variables
+
+| Variable | Purpose |
+|---|---|
+| `QONIC_CLIENT_ID` | OAuth client ID from Developer Portal |
+| `QONIC_CLIENT_SECRET` | OAuth client secret |
+| `QONIC_REDIRECT_URI` | Must match a whitelisted redirect URI exactly |
+| `QONIC_LOCAL_PORT` | Local callback server port (default: 8765) |
+| `QONIC_SCOPES` | Space-separated API scopes |
+
+## How This Repo Interfaces With Others
+
+- **Consumes**: Qonic Public API (`https://api.qonic.com` or environment-specific URL)
+- **Public repo**: Hosted at `github.com/QonicOpen/ApiPythonSample`
+- **Complements**: `api-docs` (documentation) and `dashboard-developer` (app management portal)


### PR DESCRIPTION
Add Claude Code documentation and worktree setup:

- **CLAUDE.md**: Project-specific guidance for Claude Code (tech stack, commands, conventions, cross-repo interfaces)
- **.superset/setup.sh**: Worktree setup script (dependency install, env file copy)
- **.gitignore**: Add TASK.md entry for per-worktree scratch files

Cross-repo system map lives in `~/.claude/CLAUDE.md` (user-level, not committed).