### PR TITLE
fix: fetch full library before printing codification codes

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -141,7 +141,8 @@ def handle_codifications(api: QonicApi, project_id: str):
         print("No codification libraries found")
         return
 
-    printMethods.printCodificationLibrary(libraries[0])
+    first_library = api.get_codification_library(project_id, libraries[0]["guid"])
+    printMethods.printCodificationLibrary(first_library)
 
     print("Adding new TestCodificationLibrary")
     data = {


### PR DESCRIPTION
## Summary

- The PublicAPI `GET /v1/projects/{id}/codifications` list endpoint no longer returns `codes` inline (breaking change in iQonic/Qonic#19845)
- `printCodificationLibrary` reads `data["codes"]` which would raise a `KeyError` on the list response
- Fix: fetch the full library via `get_codification_library` before passing it to `printCodificationLibrary`

## Test Plan

- [ ] Run the codifications sample flow and confirm the first library prints with its codes