### PR TITLE
fix: guard against null codes in printCodificationLibrary

### DIFF
--- a/printMethods.py
+++ b/printMethods.py
@@ -6,7 +6,7 @@ def printCodificationLibrary(data):
     print("Codes:")
     
     # Loop through classifications and properties
-    for classification in data["codes"]:
+    for classification in data.get("codes") or []:
         print(f" {classification['identification']} {classification['name']}")
         print("-----------------------------------------")
 


### PR DESCRIPTION
## Summary

- The per-library endpoint returns `"codes": null` when a library has no codes
- `printCodificationLibrary` iterated directly over `data["codes"]`, raising `TypeError: 'NoneType' is not iterable` on empty libraries
- Fix: `data.get("codes") or []`

## Related

Follow-up to #25 (codifications list endpoint breaking change).