### PR TITLE
feat: public client support and token management methods

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,5 @@ QONIC_SCOPES=projects:read projects:write models:read models:write issues:read l
 QONIC_REDIRECT_URI=http://localhost:8765/callback
 QONIC_LOCAL_PORT=8765
 QONIC_CLIENT_ID=
+# Leave blank for public clients (no client secret required)
 QONIC_CLIENT_SECRET=

--- a/QonicApi.py
+++ b/QonicApi.py
@@ -313,3 +313,12 @@ class QonicApi:
     def delete_type(self, project_id: str, library_guid: str, type_guid: str) -> None:
         self._delete(f"projects/{project_id}/types/{library_guid}/types/{type_guid}")
 
+    def list_tokens(self) -> List[Dict[str, Any]]:
+        return self.get("auth/tokens")
+
+    def revoke_token(self, token_id: str) -> None:
+        self._delete(f"auth/tokens/{token_id}")
+
+    def revoke_consent(self, app_id: str) -> None:
+        self._delete(f"auth/consents/{app_id}")
+

--- a/oauth.py
+++ b/oauth.py
@@ -107,16 +107,20 @@ def login() -> dict:
         raise SystemExit("No code received from Qonic!")
 
     # 4) Exchange code for tokens (include codeVerifier)
+    # Public clients have no secret; omit client_secret when not configured.
+    token_data = {
+        "client_id": CLIENT_ID,
+        "code": code,
+        "redirect_uri": REDIRECT_URI,
+        "code_verifier": code_verifier,
+        "grant_type": "authorization_code",
+    }
+    if CLIENT_SECRET:
+        token_data["client_secret"] = CLIENT_SECRET
+
     result = requests.post(
         f"{API_URL}/auth/token",
-        data={
-            "client_id": CLIENT_ID,
-            "client_secret": CLIENT_SECRET,
-            "code": code,
-            "redirect_uri": REDIRECT_URI,
-            "code_verifier": code_verifier,
-            "grant_type": "authorization_code"
-        },
+        data=token_data,
         timeout=30,
     ).json()
 


### PR DESCRIPTION
## Summary

Updates to align with Qonic PublicAPI security hardening (iQonic/Qonic#20318):

- **Public client support** (`oauth.py`): `client_secret` is now omitted from the token exchange when `QONIC_CLIENT_SECRET` is not set. The PublicAPI rejects a secret for public clients (`IsPublicClient: true`), so sending an empty string would return `400`. Confidential clients (with a secret configured) are unaffected.
- **Token management** (`QonicApi.py`): three new methods covering the new PublicAPI endpoints:
  - `list_tokens()` → `GET /v1/auth/tokens` — lists active, non-expired PATs for the authenticated user
  - `revoke_token(token_id)` → `DELETE /v1/auth/tokens/{id}` — revokes a specific PAT
  - `revoke_consent(app_id)` → `DELETE /v1/auth/consents/{appId}` — revokes consent and all associated PATs for an application
- **`.env.example`**: added note that `QONIC_CLIENT_SECRET` is optional for public clients.

## Test plan

- [ ] Confidential client (secret set): token exchange still works
- [ ] Public client (secret empty): token exchange omits secret, login succeeds
- [ ] `list_tokens()` returns a list of active PATs
- [ ] `revoke_token(id)` revokes a token (subsequent call returns 404)
- [ ] `revoke_consent(appId)` revokes consent + cascades to all PATs for that app